### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/TechTrendDevOps/e68ce6ac-5252-481b-b40b-af66966b751f/3a3eb0dd-5e2b-494d-b465-426c123a0fda/_apis/work/boardbadge/677c2ae4-0e70-4bc5-b2c4-5b330b7a30f0)](https://dev.azure.com/TechTrendDevOps/e68ce6ac-5252-481b-b40b-af66966b751f/_boards/board/t/3a3eb0dd-5e2b-494d-b465-426c123a0fda/Microsoft.RequirementCategory)
 # HelloWorld


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#6](https://dev.azure.com/TechTrendDevOps/e68ce6ac-5252-481b-b40b-af66966b751f/_workitems/edit/6). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.